### PR TITLE
fix: fixes wrong import path

### DIFF
--- a/src/component/truncated_text_view.tsx
+++ b/src/component/truncated_text_view.tsx
@@ -15,7 +15,7 @@ import {
   DEFAULT_LINE_HEIGHT,
   DEFAULT_NUMBER_OF_LINE,
 } from '../contacts/general';
-import type { TruncatedTextViewProps } from 'src/types/types';
+import type { TruncatedTextViewProps } from '../types/types';
 
 if (
   Platform.OS === 'android' &&


### PR DESCRIPTION
Fixes this and the fact that the Component isn't typed (props do not show up in VS Code)
![image](https://github.com/lohenyumnam/react-native-truncated-text-view/assets/886042/ac1b165b-b221-4a36-93cf-9659e1b6db23)
